### PR TITLE
Make exception dates comma-separated. Add test.

### DIFF
--- a/src/icalendar.ml
+++ b/src/icalendar.ml
@@ -696,8 +696,16 @@ module Writer = struct
   let dates_or_times_or_periods_to_ics dt buf =
     let swap f a b = f b a in
     match dt with
-    | `Dates xs -> List.iter (date_to_ics buf) xs
-    | `Datetimes xs -> List.iter (swap timestamp_to_ics buf) xs
+    | `Dates xs -> (match xs with
+        | _ -> date_to_ics buf (List.hd xs);
+          List.iter (fun x -> (Buffer.add_char buf ',';
+                               date_to_ics buf x))
+            (List.tl xs))
+    | `Datetimes xs -> (match xs with
+        | _ -> timestamp_to_ics (List.hd xs) buf;
+          List.iter (fun x -> (Buffer.add_char buf ',';
+                               swap timestamp_to_ics buf x))
+            (List.tl xs))
     | `Periods xs -> List.iter (period_to_ics buf) xs
 
   let move_tzid_to_params timestamp params =

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (test
  (name      test)
- (modules   test test_recur)
+ (modules   test test_recur test_write)
  (libraries alcotest icalendar)
  (package   icalendar))

--- a/test/test.ml
+++ b/test/test.ml
@@ -2808,6 +2808,7 @@ let tests = [
   "Decode-Encode tests", decode_encode_tests ;
   "Freebusy tests", freebusy_tests ;
   "Recurrence tests", Test_recur.tests ;
+  "Serialization tests", Test_write.tests ;
   "Timezone normalization tests", tz_normalisation_tests ;
 ]
 

--- a/test/test_write.ml
+++ b/test/test_write.ml
@@ -1,0 +1,120 @@
+open Icalendar
+
+let empty = Params.empty
+
+let to_ptime date time =
+  match Ptime.of_date_time (date, (time, 0)) with
+  | None -> Alcotest.fail "invalid date time"
+  | Some p -> p
+
+let singleton k v = Params.add k v empty
+
+let test_serialize_calendar () =
+  let expected =
+    {|BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20191109T223039Z
+LAST-MODIFIED:20191109T223039Z
+DTSTAMP:20191109T223039Z
+UID:ulre32v9-29gj-5k2h-me3x-eu4d4l7d316y
+SUMMARY:djlkfjklsfs
+TRANSP:OPAQUE
+CLASS:PUBLIC
+DTSTART;VALUE=DATE:20191104
+DTEND;VALUE=DATE:20191105
+EXDATE:20240301T000000Z,20240303T000000Z,20240305T000000Z
+END:VEVENT
+PRODID:-//Inf-IT//CalDavZAP 0.13.1//EN
+END:VCALENDAR
+|}
+
+  and input =
+    let event = {
+      uid = (empty, "ulre32v9-29gj-5k2h-me3x-eu4d4l7d316y");
+      dtstamp = (empty, to_ptime (2019, 11, 09) (22, 30, 39));
+      dtstart = (singleton Valuetype `Date , `Date (2019, 11, 04));
+      dtend_or_duration =
+        Some (`Dtend (singleton Valuetype `Date, `Date (2019, 11, 05)));
+      rrule = None;
+      props =
+        [`Created (empty, to_ptime (2019, 11, 09) (22, 30, 39));
+         `Lastmod (empty, to_ptime (2019, 11, 09) (22, 30, 39));
+         `Summary (empty, "djlkfjklsfs");
+         `Transparency (empty, `Opaque);
+         `Exdate (empty, `Datetimes
+                    [`Utc (to_ptime (2024, 03, 01) (00, 00, 00));
+                     `Utc (to_ptime (2024, 03, 03) (00, 00, 00));
+                     `Utc (to_ptime (2024, 03, 05) (00, 00, 00));
+                    ]);
+         `Class (empty, `Public) ];
+      alarms = [] }
+    in
+    (to_ics ~cr:false ( [ `Version (empty, "2.0") ;
+                `Calscale (empty, "GREGORIAN");
+                `Prodid (empty, "-//Inf-IT//CalDavZAP 0.13.1//EN") ],
+                        [ `Event event ]))
+  and sort_lines x = (String.split_on_char '\n' x) |> List.sort compare
+  in
+  print_endline input;
+  Alcotest.(check (list string)) "test serialization"
+    (sort_lines expected)
+    (sort_lines input)
+
+let test_single_exception () =
+  let expected =
+    {|BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+BEGIN:VEVENT
+CREATED:20191109T223039Z
+LAST-MODIFIED:20191109T223039Z
+DTSTAMP:20191109T223039Z
+UID:ulre32v9-29gj-5k2h-me3x-eu4d4l7d316y
+SUMMARY:djlkfjklsfs
+TRANSP:OPAQUE
+CLASS:PUBLIC
+DTSTART;VALUE=DATE:20191104
+DTEND;VALUE=DATE:20191105
+EXDATE:20240301T000000Z
+END:VEVENT
+PRODID:-//Inf-IT//CalDavZAP 0.13.1//EN
+END:VCALENDAR
+|}
+
+  and input =
+    let event = {
+      uid = (empty, "ulre32v9-29gj-5k2h-me3x-eu4d4l7d316y");
+      dtstamp = (empty, to_ptime (2019, 11, 09) (22, 30, 39));
+      dtstart = (singleton Valuetype `Date , `Date (2019, 11, 04));
+      dtend_or_duration =
+        Some (`Dtend (singleton Valuetype `Date, `Date (2019, 11, 05)));
+      rrule = None;
+      props =
+        [`Created (empty, to_ptime (2019, 11, 09) (22, 30, 39));
+         `Lastmod (empty, to_ptime (2019, 11, 09) (22, 30, 39));
+         `Summary (empty, "djlkfjklsfs");
+         `Transparency (empty, `Opaque);
+         `Exdate (empty, `Datetimes
+                    [`Utc (to_ptime (2024, 03, 01) (00, 00, 00));
+                    ]);
+         `Class (empty, `Public) ];
+      alarms = [] }
+    in
+    (to_ics ~cr:false ( [ `Version (empty, "2.0") ;
+                `Calscale (empty, "GREGORIAN");
+                `Prodid (empty, "-//Inf-IT//CalDavZAP 0.13.1//EN") ],
+                        [ `Event event ]))
+  and sort_lines x = (String.split_on_char '\n' x) |> List.sort compare
+  in
+  print_endline input;
+  Alcotest.(check (list string)) "test serializing with single exception"
+    (sort_lines expected)
+    (sort_lines input)
+
+
+let tests = [
+  "Write entire calendar correctly with exceptions", `Quick, test_serialize_calendar ;
+  "Write entire calendar correctly with single exception", `Quick, test_single_exception ;
+]


### PR DESCRIPTION
I attempted to preserve the linearity of `dates_or_times_or_periods_to_ics`.
Not really experienced in OCaml, so I'm open to suggestions to improve this.