### PR TITLE
recur_event: handle exdate

### DIFF
--- a/icalendar.opam
+++ b/icalendar.opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.10.0"}
   "dune" {>= "1.3"}
   "alcotest" {with-test}
   "fmt"


### PR DESCRIPTION
This add handling of exdate for recurring events.

I am not 100% this is correct, I am a bit unfamiliar with icalendar and the docs I found seemed under-specified but I tested it and it works. The test is included with the PR.