### PR TITLE
bug fixes manually cherry-picked from Ryan Gibb's fork

### DIFF
--- a/icalendar.opam
+++ b/icalendar.opam
@@ -20,7 +20,7 @@ build: [
 ]
 
 depends: [
-  "ocaml" {>= "4.10.0"}
+  "ocaml" {>= "4.12.0"}
   "dune" {>= "1.3"}
   "alcotest" {with-test}
   "fmt"

--- a/src/icalendar.ml
+++ b/src/icalendar.ml
@@ -840,7 +840,7 @@ module Writer = struct
     | `Seq (params, seq) -> output params (write_string (string_of_int seq))
     | `Status (params, status) -> output params (write_string (List.assoc status status_strings))
     | `Summary (params, summary) -> output params (write_string (escape_chars summary))
-    | `Url (params, uri) -> output params (write_string Uri.(pct_decode (to_string uri)))
+    | `Url (params, uri) -> output params (write_string (Uri.to_string uri))
     | `Recur_id (params, date_or_time) -> output (move_tzid_of_d_or_dt date_or_time params) (date_or_time_to_ics date_or_time)
     | `Rrule (params, recurs) -> output params (recurs_to_ics recurs)
     | `Duration (params, dur) -> output params (duration_to_ics dur)

--- a/src/icalendar.ml
+++ b/src/icalendar.ml
@@ -1112,7 +1112,12 @@ module Writer = struct
       match prop with
       | `Freebusy (params, periods) ->
         let periods' = List.map (fun (start, duration, was_explicit) -> (`Utc start, duration, was_explicit)) periods in
-        write_line cr buf key params ~dont_write_value (fun buf -> List.iter (period_to_ics buf) periods')
+        write_line cr buf key params ~dont_write_value (fun buf ->
+          match periods' with
+          | [] -> ()
+          | hd :: tl ->
+            period_to_ics buf hd;
+            List.iter (fun x -> Buffer.add_char buf ','; period_to_ics buf x) tl)
       | `Dtend_utc (params, ts) -> write_line cr buf key params ~dont_write_value (timestamp_to_ics (`Utc ts))
       | `Dtstart_utc (params, ts) -> write_line cr buf key params ~dont_write_value (timestamp_to_ics (`Utc ts))
       | #general_prop as x -> general_prop_to_ics cr buf ~dont_write_value x

--- a/src/icalendar.ml
+++ b/src/icalendar.ml
@@ -81,14 +81,14 @@ let equal_icalparameter : type a. a icalparameter -> a -> a -> bool
     | Altrep -> Uri.equal lhs_v rhs_v
     | Cn -> equal_param_value lhs_v rhs_v
     | Cutype -> equal_cutype lhs_v rhs_v
-    | Delegated_from -> List.for_all2 Uri.equal lhs_v rhs_v
-    | Delegated_to -> List.for_all2 Uri.equal lhs_v rhs_v
+    | Delegated_from -> List.equal Uri.equal lhs_v rhs_v
+    | Delegated_to -> List.equal Uri.equal lhs_v rhs_v
     | Dir -> Uri.equal lhs_v rhs_v
     | Encoding -> lhs_v = rhs_v
     | Media_type -> String.equal (fst lhs_v) (fst rhs_v) && String.equal (snd lhs_v) (snd rhs_v)
     | Fbtype -> equal_fbtype lhs_v rhs_v
     | Language -> String.equal lhs_v rhs_v
-    | Member -> List.for_all2 Uri.equal lhs_v rhs_v
+    | Member -> List.equal Uri.equal lhs_v rhs_v
     | Partstat -> equal_partstat lhs_v rhs_v
     | Range -> lhs_v = rhs_v
     | Related -> lhs_v = rhs_v
@@ -98,8 +98,8 @@ let equal_icalparameter : type a. a icalparameter -> a -> a -> bool
     | Sentby -> Uri.equal lhs_v rhs_v
     | Tzid -> fst lhs_v = fst rhs_v && String.equal (snd lhs_v) (snd rhs_v)
     | Valuetype -> equal_valuetype lhs_v rhs_v
-    | Iana_param _ -> List.for_all2 equal_param_value lhs_v rhs_v
-    | Xparam _ -> List.for_all2 equal_param_value lhs_v rhs_v
+    | Iana_param _ -> List.equal equal_param_value lhs_v rhs_v
+    | Xparam _ -> List.equal equal_param_value lhs_v rhs_v
 
 let pp_icalparameter : type a. Format.formatter -> a icalparameter -> a -> unit
   = fun fmt k v ->

--- a/src/recurrence.ml
+++ b/src/recurrence.ml
@@ -312,7 +312,9 @@ let filter_bysetpos bysetpos set =
     let l = List.length set in
     let positions = List.map (fun i -> if i < 0 then l + i else pred i) p |>
     List.sort_uniq compare in
-    List.map (List.nth set) positions
+    List.filter_map (fun idx ->
+      if idx >= 0 && idx < l then Some (List.nth set idx) else None)
+      positions
 
 let compare_dates (y, m, d) (y', m', d') = match compare y y' with
   | 0 -> begin match compare m m' with

--- a/src/recurrence.ml
+++ b/src/recurrence.ml
@@ -402,8 +402,8 @@ let init_until until f = { until ; f }
 
 let next_until g =
   let candidate = next_rr g.f in
-  (* desired behaviour if Ptime.equal? need to check *)
-  if Ptime.is_earlier ~than:g.until candidate
+  (* RFC 5545 Section 3.3.10: UNTIL bounds the recurrence in an inclusive manner *)
+  if not (Ptime.is_later ~than:g.until candidate)
   then Some candidate
   else None
 

--- a/src/recurrence.ml
+++ b/src/recurrence.ml
@@ -101,7 +101,7 @@ let days_since_start_of_year (y, m, d) =
 let days_until_end_of_year (y, m, d) =
   let rec md = function
     | 12 -> 31 - d
-    | n -> days_in_month y m + md (succ n)
+    | n -> days_in_month y n + md (succ n)
   in
   md m
 

--- a/src/recurrence.ml
+++ b/src/recurrence.ml
@@ -108,22 +108,28 @@ let days_until_end_of_year (y, m, d) =
 let weekday (y, m, d) =
   let d1_to_date = pred @@ days_since_start_of_year (y, m, d) in
   let epoch_to_d1 =
-    let rec go = function
-      | 1969 -> 0
-      | x -> days_in_year x + go (pred x)
-    in
-    go (pred y)
+    if y >= 1970 then
+      let rec go = function
+        | 1969 -> 0
+        | x -> days_in_year x + go (pred x)
+      in
+      go (pred y)
+    else
+      (* For years before 1970, count days backward *)
+      let rec go = function
+        | 1970 -> 0
+        | x -> -(days_in_year x) + go (succ x)
+      in
+      go y
   in
   (* 1970/01/01 was a thursday! *)
   match (epoch_to_d1 + d1_to_date) mod 7 with
-  | 0 -> `Thursday
-  | 1 -> `Friday
-  | 2 -> `Saturday
-  | 3 -> `Sunday
-  | 4 -> `Monday
-  | 5 -> `Tuesday
-  | 6 -> `Wednesday
-  | _ -> invalid_arg "bad input for weekday"
+  | n when n >= 0 ->
+    [| `Thursday; `Friday; `Saturday; `Sunday; `Monday; `Tuesday; `Wednesday |].(n)
+  | n ->
+    (* OCaml mod can be negative for negative inputs *)
+    [| `Thursday; `Friday; `Saturday; `Sunday; `Monday; `Tuesday; `Wednesday |].(n + 7)
+
 
 let wd = function
   | `Sunday -> 0

--- a/src/recurrence.ml
+++ b/src/recurrence.ml
@@ -220,17 +220,15 @@ let yearly_weekday_matches (y, m, d) (x, wd) =
   let weekday = weekday (y, m, d) in
   if wd_is_weekday weekday wd
   then
-    let n =
-      let d = days_since_start_of_year (y, m, d) in
-      succ (d / 7)
-    in
+    let doy = days_since_start_of_year (y, m, d) in
+    let n = succ ((doy - 1) / 7) in
     match x with
     | 0 -> true
     | x ->
       if x > 0
       then n = x
       else
-        let total = n + (days_in_year y - n) / 7 in
+        let total = n + (days_in_year y - doy) / 7 in
         n = total + succ x
   else false
 

--- a/src/recurrence.ml
+++ b/src/recurrence.ml
@@ -144,14 +144,18 @@ let wd = function
   | `Friday -> 5
   | `Saturday -> 6
 
-let w1d1_offset year =
-  let wd = wd (weekday (year, 01, 01)) in
-  (11 - wd) mod 7 - 3
+let w1d1_offset wkst year =
+  let jan1_wd = wd (weekday (year, 01, 01)) in
+  let wkst_wd = wd wkst in
+  let days_into_week = (jan1_wd - wkst_wd + 7) mod 7 in
+  if days_into_week <= 3 then
+    -days_into_week
+  else
+    7 - days_into_week
 
-(* TODO needs to be parametrised by wkst! *)
 (* day 1 of week 1 in a given year *)
-let w1d1 year =
-  let off = w1d1_offset year
+let w1d1 wkst year =
+  let off = w1d1_offset wkst year
   and date = (year, 01, 01)
   in
   if off < 0
@@ -160,28 +164,28 @@ let w1d1 year =
 
 (* returns (year * weeknumber), year can be last year, this year or next year *)
 (* (date - d1w1) / 7 + 1 *)
-let rec week_number (y, m, d) =
+let rec week_number wkst (y, m, d) =
   let days = pred @@ days_since_start_of_year (y, m, d)
-  and off = w1d1_offset y
+  and off = w1d1_offset wkst y
   in
   let ndays = days - off in
   if ndays < 0
-  then week_number (pred y, 12, 31)
+  then week_number wkst (pred y, 12, 31)
   else
-    let next_off = w1d1_offset (succ y) in
+    let next_off = w1d1_offset wkst (succ y) in
     if next_off < 0 && days_until_end_of_year (y, m, d) + next_off <= 0
     then (succ y, 1)
     else (y, ndays / 7 + 1)
 
-let weeks y =
-  let off = w1d1_offset (succ y) in
+let weeks wkst y =
+  let off = w1d1_offset wkst (succ y) in
   let last_day = (y, 12, 31) in
   let last =
     if off >= 0
     then add_days off last_day
     else sub_days (abs (pred off)) last_day
   in
-  snd (week_number last)
+  snd (week_number wkst last)
 
 (* for matches: if n is negative, index from end, which is defined as -1 *)
 
@@ -192,12 +196,12 @@ let monthday_matches (y, m, d) n =
   then d = days_in_month y m + succ n
   else false
 
-let weekno_matches date wn =
-  let y, week = week_number date in
+let weekno_matches wkst date wn =
+  let y, week = week_number wkst date in
   if week = wn
   then true
   else if wn < 0
-  then week = weeks y + succ wn
+  then week = weeks wkst y + succ wn
   else false
 
 let yearday_matches (y, m, d) n =
@@ -242,7 +246,7 @@ let yearly_weekday_matches (y, m, d) (x, wd) =
         n = total + succ x
   else false
 
-let is_occurence s_date freq (bymonth, byweekno, byyearday, bymonthday, byday) =
+let is_occurence s_date freq wkst (bymonth, byweekno, byyearday, bymonthday, byday) =
   match freq with
   | `Daily ->
     let (y, m, d) = s_date in
@@ -297,7 +301,7 @@ let is_occurence s_date freq (bymonth, byweekno, byyearday, bymonthday, byday) =
     in
     let is_byweekno () = match byweekno with
       | None -> true
-      | Some wn -> List.exists (weekno_matches (y, m, d)) wn
+      | Some wn -> List.exists (weekno_matches wkst (y, m, d)) wn
     in
     let is_byyearday () = match byyearday with
       | None -> true
@@ -362,7 +366,7 @@ let init_rr next_interval freq interval filters bysetpos wkst =
     let rec next_elem d =
       if in_set d
       then let d' = add_days 1 d in
-        if is_occurence d freq filters
+        if is_occurence d freq wkst filters
         then d :: next_elem d'
         else next_elem d'
       else []

--- a/src/recurrence.ml
+++ b/src/recurrence.ml
@@ -123,13 +123,17 @@ let weekday (y, m, d) =
       go y
   in
   (* 1970/01/01 was a thursday! *)
-  match (epoch_to_d1 + d1_to_date) mod 7 with
-  | n when n >= 0 ->
-    [| `Thursday; `Friday; `Saturday; `Sunday; `Monday; `Tuesday; `Wednesday |].(n)
-  | n ->
-    (* OCaml mod can be negative for negative inputs *)
-    [| `Thursday; `Friday; `Saturday; `Sunday; `Monday; `Tuesday; `Wednesday |].(n + 7)
-
+  let day = (epoch_to_d1 + d1_to_date) mod 7 in
+  let day = if day < 0 then day + 7 else day in
+  match day with
+  | 0 -> `Thursday
+  | 1 -> `Friday
+  | 2 -> `Saturday
+  | 3 -> `Sunday
+  | 4 -> `Monday
+  | 5 -> `Tuesday
+  | 6 -> `Wednesday
+  | _ -> invalid_arg "bad input for weekday"
 
 let wd = function
   | `Sunday -> 0

--- a/test/test.ml
+++ b/test/test.ml
@@ -3320,6 +3320,37 @@ let param_equality_tests = [
   "Delegated_from different lengths", `Quick, param_equality_different_lengths ;
 ]
 
+let calendar_until_date = {|BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VEVENT
+UID:until-date-test
+DTSTAMP:20250221T173943Z
+SUMMARY:date event
+DTSTART;VALUE=DATE:20250301
+DTEND;VALUE=DATE:20250302
+RRULE:FREQ=DAILY;UNTIL=20250305
+END:VEVENT
+END:VCALENDAR|}
+
+let until_bare_date () =
+  let calendar = Icalendar.parse calendar_until_date |> Result.get_ok in
+  let event = List.find_map (function `Event e -> Some e | _ -> None) (snd calendar) |> Option.get in
+  let get_events = Icalendar.recur_events event in
+  let rec collect acc =
+    match get_events () with
+    | None -> List.rev acc
+    | Some e -> collect (e :: acc)
+  in
+  let events = collect [] in
+  (* UNTIL=20250305 should include Mar 1-5 (5 days, inclusive) *)
+  Alcotest.(check int) "UNTIL bare date gives correct count" 5 (List.length events)
+
+let until_date_tests = [
+  "UNTIL with bare date in RRULE", `Quick, until_bare_date ;
+]
+
+
 let tests = [
   "Object tests", object_tests ;
   "Timezone tests", timezone_tests ;
@@ -3330,6 +3361,7 @@ let tests = [
   "Serialization tests", Test_write.tests ;
   "Timezone normalization tests", tz_normalisation_tests ;
   "Parameter equality tests", param_equality_tests ;
+  "UNTIL date tests", until_date_tests ;
 ]
 
 let () =

--- a/test/test.ml
+++ b/test/test.ml
@@ -3295,6 +3295,31 @@ let tz_normalisation_tests = [
   "timestamp doesn't exist (standard -> DST)", `Quick, ts_non_existing ;
 ]
 
+let param_equality_different_lengths () =
+  (* Comparing events with different-length Delegated_from lists
+     should return false, not crash with Invalid_argument from List.for_all2 *)
+  let p1 = Params.add Delegated_from [Uri.of_string "mailto:a@b.com"] empty in
+  let p2 = Params.add Delegated_from [Uri.of_string "mailto:a@b.com"; Uri.of_string "mailto:c@d.com"] empty in
+  let make_cal params =
+    let event = {
+      uid = (empty, "test-uid");
+      dtstamp = (empty, to_ptime (2020, 01, 01) (00, 00, 00));
+      dtstart = (empty, `Datetime (`Utc (to_ptime (2020, 01, 01) (09, 00, 00))));
+      dtend_or_duration = None;
+      rrule = None;
+      props = [`Attendee (params, Uri.of_string "mailto:a@b.com")];
+      alarms = [] }
+    in
+    ([`Version (empty, "2.0"); `Prodid (empty, "-//Test//Test//EN")], [`Event event])
+  in
+  let c1 = make_cal p1 and c2 = make_cal p2 in
+  Alcotest.(check bool) "different-length Delegated_from params are not equal"
+    false (equal_calendar c1 c2)
+
+let param_equality_tests = [
+  "Delegated_from different lengths", `Quick, param_equality_different_lengths ;
+]
+
 let tests = [
   "Object tests", object_tests ;
   "Timezone tests", timezone_tests ;
@@ -3304,6 +3329,7 @@ let tests = [
   "Recurrence tests", Test_recur.tests ;
   "Serialization tests", Test_write.tests ;
   "Timezone normalization tests", tz_normalisation_tests ;
+  "Parameter equality tests", param_equality_tests ;
 ]
 
 let () =

--- a/test/test_recur.ml
+++ b/test/test_recur.ml
@@ -844,6 +844,19 @@ let ex_recurrence_id () =
 |}
               str)
 
+let days_until_eoy () =
+  (* Bug: days_until_end_of_year used the starting month for all months
+     in the recursion instead of the current iteration month.
+     March 15 non-leap year: (31-15) + 30+31+30+31+31+30+31+30+31 = 291 *)
+  Alcotest.(check int) "days until end of year from March 15"
+    291 (Recurrence.days_until_end_of_year (2023, 3, 15)) ;
+  (* Feb 15 non-leap year: (28-15) + 31+30+31+30+31+31+30+31+30+31 = 319 *)
+  Alcotest.(check int) "days until end of year from Feb 15"
+    319 (Recurrence.days_until_end_of_year (2023, 2, 15)) ;
+  (* Dec 25: 31-25 = 6 *)
+  Alcotest.(check int) "days until end of year from Dec 25"
+    6 (Recurrence.days_until_end_of_year (2023, 12, 25))
+
 let until_inclusive () =
   (* UNTIL should be inclusive per RFC 5545 Section 3.3.10:
      "The UNTIL rule part defines a DATE or DATE-TIME value that bounds
@@ -904,4 +917,5 @@ let tests = [
   "example 39: recurrence-id", `Quick, ex_recurrence_id ;
   "example 40: multiple exdates", `Quick, multiple_exdates ;
   "UNTIL is inclusive", `Quick, until_inclusive ;
+  "days_until_end_of_year", `Quick, days_until_eoy ;
 ]

--- a/test/test_recur.ml
+++ b/test/test_recur.ml
@@ -857,6 +857,24 @@ let days_until_eoy () =
   Alcotest.(check int) "days until end of year from Dec 25"
     6 (Recurrence.days_until_end_of_year (2023, 12, 25))
 
+let yearly_weekday_matches_test () =
+  (* Test yearly_weekday_matches directly to avoid infinite loops from the
+     buggy recurrence generator when no day matches.
+
+     2002-01-01 is Tuesday, so first Monday is Jan 7 (day 7 of year).
+     Bug: succ(7/7) = 2 (wrong), correct: succ((7-1)/7) = 1.
+     Also tests negative index: Dec 30 2002 is the last Monday. *)
+  Alcotest.(check bool) "Jan 7 2002 is 1st Monday of year"
+    true (Recurrence.yearly_weekday_matches (2002, 1, 7) (1, `Monday)) ;
+  Alcotest.(check bool) "May 20 2002 is 20th Monday of year"
+    true (Recurrence.yearly_weekday_matches (2002, 5, 20) (20, `Monday)) ;
+  Alcotest.(check bool) "May 13 2002 is NOT 20th Monday of year"
+    false (Recurrence.yearly_weekday_matches (2002, 5, 13) (20, `Monday)) ;
+  Alcotest.(check bool) "Dec 30 2002 is last Monday of year"
+    true (Recurrence.yearly_weekday_matches (2002, 12, 30) (-1, `Monday)) ;
+  Alcotest.(check bool) "Dec 23 2002 is NOT last Monday of year"
+    false (Recurrence.yearly_weekday_matches (2002, 12, 23) (-1, `Monday))
+
 let until_inclusive () =
   (* UNTIL should be inclusive per RFC 5545 Section 3.3.10:
      "The UNTIL rule part defines a DATE or DATE-TIME value that bounds
@@ -918,4 +936,5 @@ let tests = [
   "example 40: multiple exdates", `Quick, multiple_exdates ;
   "UNTIL is inclusive", `Quick, until_inclusive ;
   "days_until_end_of_year", `Quick, days_until_eoy ;
+  "yearly_weekday_matches", `Quick, yearly_weekday_matches_test ;
 ]

--- a/test/test_recur.ml
+++ b/test/test_recur.ml
@@ -844,6 +844,24 @@ let ex_recurrence_id () =
 |}
               str)
 
+let until_inclusive () =
+  (* UNTIL should be inclusive per RFC 5545 Section 3.3.10:
+     "The UNTIL rule part defines a DATE or DATE-TIME value that bounds
+     the recurrence rule in an inclusive manner." *)
+  let date = (1997, 09, 02)
+  and time = (09, 00, 00)
+  (* UNTIL exactly matches the 10th occurrence *)
+  and rrule = (`Daily, Some (`Until (`Utc (to_ptime (1997, 09, 11) (09, 00, 00)))), None, [])
+  and res = [
+    (1997, 09, 02) ; (1997, 09, 03) ; (1997, 09, 04) ; (1997, 09, 05) ;
+    (1997, 09, 06) ; (1997, 09, 07) ; (1997, 09, 08) ; (1997, 09, 09) ;
+    (1997, 09, 10) ; (1997, 09, 11)  (* this last one must be included *)
+  ]
+  in
+  Alcotest.(check (list p) "UNTIL boundary is inclusive"
+              (List.map (fun d -> to_ptime d time) res)
+              (all_events date time rrule))
+
 let tests = [
   "example 1", `Quick, ex_1 ;
   "example 2", `Quick, ex_2 ;
@@ -885,4 +903,5 @@ let tests = [
   "example 38: exdate", `Quick, exdate ;
   "example 39: recurrence-id", `Quick, ex_recurrence_id ;
   "example 40: multiple exdates", `Quick, multiple_exdates ;
+  "UNTIL is inclusive", `Quick, until_inclusive ;
 ]

--- a/test/test_recur.ml
+++ b/test/test_recur.ml
@@ -893,6 +893,20 @@ let until_inclusive () =
               (List.map (fun d -> to_ptime d time) res)
               (all_events date time rrule))
 
+let weekday_pre_1970 () =
+  (* weekday must work for dates before 1970. Previously, epoch_to_d1
+     only had a base case for 1969 and recursed via pred, diverging
+     for years < 1970. *)
+  (* 1969-07-20 was a Sunday (Apollo 11 moon landing) *)
+  Alcotest.(check bool) "1969-07-20 is Sunday"
+    true (Recurrence.wd_is_weekday (Recurrence.weekday (1969, 7, 20)) `Sunday) ;
+  (* 1900-01-01 was a Monday *)
+  Alcotest.(check bool) "1900-01-01 is Monday"
+    true (Recurrence.wd_is_weekday (Recurrence.weekday (1900, 1, 1)) `Monday) ;
+  (* 1582-10-15 was a Friday (start of Gregorian calendar) *)
+  Alcotest.(check bool) "1582-10-15 is Friday"
+    true (Recurrence.wd_is_weekday (Recurrence.weekday (1582, 10, 15)) `Friday)
+
 let bysetpos_out_of_bounds () =
   (* BYSETPOS=5 with a set that has fewer than 5 elements should not crash.
      RFC 5545: invalid recurrence instances are ignored.
@@ -963,4 +977,5 @@ let tests = [
   "days_until_end_of_year", `Quick, days_until_eoy ;
   "yearly_weekday_matches", `Quick, yearly_weekday_matches_test ;
   "BYSETPOS out-of-bounds", `Quick, bysetpos_out_of_bounds ;
+  "weekday pre-1970", `Quick, weekday_pre_1970 ;
 ]

--- a/test/test_recur.ml
+++ b/test/test_recur.ml
@@ -893,6 +893,31 @@ let until_inclusive () =
               (List.map (fun d -> to_ptime d time) res)
               (all_events date time rrule))
 
+let bysetpos_out_of_bounds () =
+  (* BYSETPOS=5 with a set that has fewer than 5 elements should not crash.
+     RFC 5545: invalid recurrence instances are ignored.
+     MONTHLY;BYDAY=MO;BYSETPOS=1,5 - first and fifth Monday, but months
+     only have 4-5 Mondays, so BYSETPOS=5 may not exist some months. *)
+  let date = (2025, 01, 06)
+  and time = (09, 00, 00)
+  and rrule = (`Monthly, Some (`Count 5), None,
+    [`Byday [(0, `Monday)]; `Bysetposday [1; 5]])
+  and res = [
+    (* Jan 2025: 5 Mondays (6,13,20,27 -- wait, also Jan has Mon 6,13,20,27 = 4 Mondays,
+       but also need to check... Jan 2025 starts on Wednesday.
+       Mondays in Jan 2025: 6, 13, 20, 27 = 4 Mondays. BYSETPOS=1 -> 6th, BYSETPOS=5 -> skip.
+       Feb 2025: Mondays 3, 10, 17, 24 = 4. BYSETPOS=1 -> 3rd, BYSETPOS=5 -> skip.
+       Mar 2025: Mondays 3, 10, 17, 24, 31 = 5. BYSETPOS=1 -> 3rd, BYSETPOS=5 -> 31st.
+       Apr 2025: Mondays 7, 14, 21, 28 = 4. BYSETPOS=1 -> 7th.
+       May 2025: Mondays 5, 12, 19, 26 = 4. BYSETPOS=1 -> 5th. *)
+    (2025, 01, 06) ; (2025, 02, 03) ; (2025, 03, 03) ;
+    (2025, 03, 31) ; (2025, 04, 07)
+  ]
+  in
+  Alcotest.(check (list p) "BYSETPOS out-of-bounds is skipped"
+              (List.map (fun d -> to_ptime d time) res)
+              (all_events date time rrule))
+
 let tests = [
   "example 1", `Quick, ex_1 ;
   "example 2", `Quick, ex_2 ;
@@ -937,4 +962,5 @@ let tests = [
   "UNTIL is inclusive", `Quick, until_inclusive ;
   "days_until_end_of_year", `Quick, days_until_eoy ;
   "yearly_weekday_matches", `Quick, yearly_weekday_matches_test ;
+  "BYSETPOS out-of-bounds", `Quick, bysetpos_out_of_bounds ;
 ]

--- a/test/test_recur.ml
+++ b/test/test_recur.ml
@@ -907,6 +907,23 @@ let weekday_pre_1970 () =
   Alcotest.(check bool) "1582-10-15 is Friday"
     true (Recurrence.wd_is_weekday (Recurrence.weekday (1582, 10, 15)) `Friday)
 
+let byweekno_wkst () =
+  (* 2017-01-01 is Sunday.
+     With Monday WKST (ISO): Jan 1 is in the last week of 2016, so
+     week 1 of 2017 starts Jan 2 (Monday). Jan 1 is NOT in week 1.
+     With Sunday WKST: Jan 1 IS the first day of week 1 of 2017. *)
+  Alcotest.(check bool) "Jan 1 2017 is NOT in week 1 with Monday WKST"
+    false (Recurrence.weekno_matches `Monday (2017, 1, 1) 1) ;
+  Alcotest.(check bool) "Jan 1 2017 IS in week 1 with Sunday WKST"
+    true (Recurrence.weekno_matches `Sunday (2017, 1, 1) 1) ;
+  (* Jan 2 2017 is Monday.
+     With Monday WKST: Jan 2 is week 1 day 1.
+     With Sunday WKST: Jan 2 is week 1 day 2. Both agree it's week 1. *)
+  Alcotest.(check bool) "Jan 2 2017 is in week 1 with Monday WKST"
+    true (Recurrence.weekno_matches `Monday (2017, 1, 2) 1) ;
+  Alcotest.(check bool) "Jan 2 2017 is in week 1 with Sunday WKST"
+    true (Recurrence.weekno_matches `Sunday (2017, 1, 2) 1)
+
 let bysetpos_out_of_bounds () =
   (* BYSETPOS=5 with a set that has fewer than 5 elements should not crash.
      RFC 5545: invalid recurrence instances are ignored.
@@ -978,4 +995,5 @@ let tests = [
   "yearly_weekday_matches", `Quick, yearly_weekday_matches_test ;
   "BYSETPOS out-of-bounds", `Quick, bysetpos_out_of_bounds ;
   "weekday pre-1970", `Quick, weekday_pre_1970 ;
+  "BYWEEKNO respects WKST", `Quick, byweekno_wkst ;
 ]

--- a/test/test_write.ml
+++ b/test/test_write.ml
@@ -117,7 +117,45 @@ END:VCALENDAR
     (sort_lines input)
 
 
+let test_freebusy_comma_separators () =
+  let expected =
+    {|BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Test//EN
+BEGIN:VFREEBUSY
+DTSTAMP:20200101T000000Z
+UID:fb-test-1
+DTSTART:20200101T080000Z
+DTEND:20200101T180000Z
+FREEBUSY:20200101T080000Z/PT1H,20200101T100000Z/PT2H
+END:VFREEBUSY
+END:VCALENDAR
+|}
+  in
+  let p1 = (to_ptime (2020, 01, 01) (08, 00, 00), Ptime.Span.of_int_s 3600, false) in
+  let p2 = (to_ptime (2020, 01, 01) (10, 00, 00), Ptime.Span.of_int_s 7200, false) in
+  let freebusy : Icalendar.component =
+    `Freebusy [
+      `Dtstamp (empty, to_ptime (2020, 01, 01) (00, 00, 00));
+      `Uid (empty, "fb-test-1");
+      `Dtstart_utc (empty, to_ptime (2020, 01, 01) (08, 00, 00));
+      `Dtend_utc (empty, to_ptime (2020, 01, 01) (18, 00, 00));
+      `Freebusy (empty, [ p1; p2 ]);
+    ]
+  in
+  let input =
+    to_ics ~cr:false ( [ `Version (empty, "2.0") ;
+                          `Prodid (empty, "-//Test//Test//EN") ],
+                        [ freebusy ])
+  in
+  let sort_lines x = (String.split_on_char '\n' x) |> List.sort compare in
+  print_endline input;
+  Alcotest.(check (list string)) "FREEBUSY periods separated by commas"
+    (sort_lines expected)
+    (sort_lines input)
+
 let tests = [
   "Write entire calendar correctly with exceptions", `Quick, test_serialize_calendar ;
   "Write entire calendar correctly with single exception", `Quick, test_single_exception ;
+  "FREEBUSY periods have comma separators", `Quick, test_freebusy_comma_separators ;
 ]

--- a/test/test_write.ml
+++ b/test/test_write.ml
@@ -154,8 +154,45 @@ END:VCALENDAR
     (sort_lines expected)
     (sort_lines input)
 
+let test_url_roundtrip () =
+  (* URL with percent-encoded characters should round-trip correctly.
+     The writer was using Uri.pct_decode which decoded %20 to spaces,
+     breaking round-trip fidelity. *)
+  let url = "https://example.com/path%20with%20spaces?q=hello%26world" in
+  let event = {
+    uid = (empty, "url-test");
+    dtstamp = (empty, to_ptime (2020, 01, 01) (00, 00, 00));
+    dtstart = (singleton Valuetype `Date, `Date (2020, 01, 01));
+    dtend_or_duration = None;
+    rrule = None;
+    props = [`Url (empty, Uri.of_string url)];
+    alarms = []
+  } in
+  let output =
+    to_ics ~cr:false ( [ `Version (empty, "2.0") ;
+                          `Prodid (empty, "-//Test//Test//EN") ],
+                        [ `Event event ])
+  in
+  (* Unfold then check URL line *)
+  let buf = Buffer.create (String.length output) in
+  let i = ref 0 in
+  let len = String.length output in
+  while !i < len do
+    if !i + 1 < len && output.[!i] = '\n' && output.[!i + 1] = ' ' then
+      i := !i + 2
+    else (
+      Buffer.add_char buf output.[!i];
+      i := !i + 1)
+  done;
+  let unfolded = Buffer.contents buf in
+  let expected_line = "URL:" ^ url in
+  let found = List.exists (fun line -> line = expected_line)
+    (String.split_on_char '\n' unfolded) in
+  Alcotest.(check bool) "URL with percent-encoding round-trips correctly" true found
+
 let tests = [
   "Write entire calendar correctly with exceptions", `Quick, test_serialize_calendar ;
   "Write entire calendar correctly with single exception", `Quick, test_single_exception ;
   "FREEBUSY periods have comma separators", `Quick, test_freebusy_comma_separators ;
+  "URL percent-encoding preserved", `Quick, test_url_roundtrip ;
 ]


### PR DESCRIPTION
Dear @RyanGibb, I looked through your "claude" branch, and picked the commits that looked good to me (reviewed manually, also checked RFC). Thanks a lot for this work.

I did _not_ include the following patches:
- c49d068015f25631ddffc2122a734915b451fd12 (Include RDATE dates in recurrence set) - the commit uses `ref` (we can certainly use some arguments to the recursive function)
- c46b56f75374f74105c1eb1af20421ec82d95600 (Add line folding to writer per RFC 5545 Section 3.1) - I prefer to use the opam package unstrctrd for this (or at least evaluate why not if not)
- 0722a633ed8df8f5ec2fa78d29aa7a8b31687f39 (parse_datetime: accept bare DATE values (YYYYMMDD)) - "this makes the public API match" -- I know this is used in CalDAV, but I'm not sure we need it in this form. This will have to wait until we find further test cases for CalDAV on that, and actual use. -- or of course another package that depends on the semantics of parse_datetime to accept bare DATE values.

It would be great if you could comment what you think about these commits.